### PR TITLE
[ENH] Spectra transformers

### DIFF
--- a/pySNOM/spectra.py
+++ b/pySNOM/spectra.py
@@ -174,12 +174,14 @@ class ConstantNormalize(Transformation):
     def transform(self, spectrum, wnaxis):
         if self.from_spectrum:
             data_idx = np.argmin(np.abs(wnaxis-self.value))
-            self.value = spectrum[data_idx]
+            data_value = spectrum[data_idx]
+        else:
+            data_value = self.value
 
         if self.datatype == DataTypes.Amplitude:
-            return spectrum / self.value
+            return spectrum / data_value
         else:
-            return spectrum - self.value
+            return spectrum - data_value
 
 class RotatePhase(Transformation):
     def __init__(self, degree=0.0, wn_ref=1000.0, constant_shift=False):

--- a/pySNOM/spectra.py
+++ b/pySNOM/spectra.py
@@ -147,6 +147,29 @@ class Transformation:
     def transform(self, data):
         raise NotImplementedError()
 
+class Cut(Transformation):
+    def __init__(self, wavenumber1=0.0, wavenumber2=1000.0):
+        self.wn1 = wavenumber1
+        self.wn2 = wavenumber2
+
+    def transform(self, spectrum, wnaxis):
+        wn1idx = np.argmin(abs(wnaxis - self.wn1))
+        wn2idx = np.argmin(abs(wnaxis - self.wn2))
+        return spectrum[wn1idx:wn2idx], wnaxis[wn1idx:wn2idx]
+    
+class Scale(Transformation):
+    def __init__(self, factor=1.0, datatype=DataTypes.Phase):
+        self.factor = factor
+        self.datatype = datatype
+
+    def transform(self, spectrum):
+        if self.datatype == DataTypes.Phase:
+            if not np.iscomplex(spectrum).any():
+                spectrum = np.exp(spectrum * self.factor * complex(1j))
+            return np.angle(spectrum)
+        else:
+            return spectrum * self.factor
+
 
 class LinearNormalize(Transformation):
     def __init__(self, wavenumber1=0.0, wavenumber2=1000.0, datatype=DataTypes.Phase):

--- a/pySNOM/spectra.py
+++ b/pySNOM/spectra.py
@@ -165,17 +165,36 @@ class LinearNormalize(Transformation):
         else:
             return spectrum - (m * wnaxis + C)
 
+class ConstantNormalize(Transformation):
+    def __init__(self, value=1.0, from_spectrum=False, datatype=DataTypes.Phase):
+        self.value = value
+        self.from_spectrum = from_spectrum
+        self.datatype = datatype
+
+    def transform(self, spectrum, wnaxis):
+        if self.from_spectrum:
+            data_idx = np.argmin(np.abs(wnaxis-self.value))
+            self.value = spectrum[data_idx]
+
+        if self.datatype == DataTypes.Amplitude:
+            return spectrum / self.value
+        else:
+            return spectrum - self.value
 
 class RotatePhase(Transformation):
-    def __init__(self, degree=0.0, wn_ref=1000.0):
+    def __init__(self, degree=0.0, wn_ref=1000.0, constant_shift=False):
         self.wn_ref = wn_ref
         self.degree = degree
+        self.constant_shift = constant_shift
 
     def transform(self, spectrum, wnaxis):
         if not np.iscomplex(spectrum).any():
             spectrum = np.exp(spectrum * complex(1j))
 
-        angles = wnaxis * np.deg2rad(self.degree) / self.wn_ref
+        if not self.constant_shift:
+            angles = wnaxis * np.deg2rad(self.degree) / self.wn_ref
+        else:
+            angles = np.deg2rad(self.degree)
 
         return np.angle(spectrum * np.exp(angles * complex(1j)))
 

--- a/pySNOM/tests/test_spectra.py
+++ b/pySNOM/tests/test_spectra.py
@@ -145,6 +145,38 @@ class test_Neaspectrum(unittest.TestCase):
 
         np.testing.assert_allclose(normalized, np.ones_like(spectrum), atol=1e-12)
 
+    def test_cut_transformation(self):
+        spectrum = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        wnaxis = np.array([900.0, 1000.0, 1100.0, 1200.0, 1300.0])
+
+        cut_spectrum, cut_wnaxis = spectra.Cut(
+            wavenumber1=1000.0,
+            wavenumber2=1300.0,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(cut_spectrum, np.array([20.0, 30.0, 40.0]))
+        np.testing.assert_allclose(cut_wnaxis, np.array([1000.0, 1100.0, 1200.0]))
+
+    def test_scale_transformation_phase(self):
+        spectrum = np.array([0.0, np.pi / 4.0])
+
+        scaled = spectra.Scale(
+            factor=2.0,
+            datatype=spectra.DataTypes.Phase,
+        ).transform(spectrum)
+
+        np.testing.assert_allclose(scaled, np.array([0.0, np.pi / 2.0]), atol=1e-12)
+
+    def test_scale_transformation_amplitude(self):
+        spectrum = np.array([1.0, 2.0, 3.0])
+
+        scaled = spectra.Scale(
+            factor=3.0,
+            datatype=spectra.DataTypes.Amplitude,
+        ).transform(spectrum)
+
+        np.testing.assert_allclose(scaled, np.array([3.0, 6.0, 9.0]), atol=1e-12)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pySNOM/tests/test_spectra.py
+++ b/pySNOM/tests/test_spectra.py
@@ -68,6 +68,83 @@ class test_Neaspectrum(unittest.TestCase):
         np.testing.assert_almost_equal(normdata[1000], 0.7278023)
         np.testing.assert_almost_equal(corrdata[1000], 0.9795999)
 
+    def test_constant_normalize_from_spectrum_amplitude(self):
+        spectrum = np.array([2.0, 4.0, 8.0])
+        wnaxis = np.array([900.0, 1000.0, 1100.0])
+
+        # value=1005 selects the nearest wavenumber point at 1000 (index 1).
+        normalized = spectra.ConstantNormalize(
+            value=1005.0,
+            from_spectrum=True,
+            datatype=spectra.DataTypes.Amplitude,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(normalized, np.array([0.5, 1.0, 2.0]))
+
+    def test_constant_normalize_from_spectrum_phase(self):
+        spectrum = np.array([0.2, 0.5, 1.1])
+        wnaxis = np.array([900.0, 1000.0, 1100.0])
+
+        # value=1002 selects the nearest wavenumber point at 1000 (index 1).
+        normalized = spectra.ConstantNormalize(
+            value=1002.0,
+            from_spectrum=True,
+            datatype=spectra.DataTypes.Phase,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(normalized, np.array([-0.3, 0.0, 0.6]))
+
+    def test_shift_phase_to_zero_linear_phase(self):
+        wnaxis = np.array([900.0, 1000.0, 1100.0, 1200.0])
+        # Linear phase with offset and slope; ShiftPhaseToZero should remove both.
+        spectrum = np.array([0.0, 0.1, 0.2, 0.3])
+
+        shifted = spectra.ShiftPhaseToZero(
+            wavenumber1=1000.0,
+            wavenumber2=1200.0,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(shifted, np.zeros_like(shifted), atol=1e-12)
+
+    def test_rotate_phase_wavenumber_scaled_shift(self):
+        wnaxis = np.array([500.0, 1000.0, 1500.0])
+        spectrum = np.array([0.0, 0.0, 0.0])
+
+        rotated = spectra.RotatePhase(
+            degree=90.0,
+            wn_ref=1000.0,
+            constant_shift=False,
+        ).transform(spectrum, wnaxis)
+
+        expected = np.array([np.pi / 4.0, np.pi / 2.0, 3.0 * np.pi / 4.0])
+        np.testing.assert_allclose(rotated, expected, atol=1e-12)
+
+    def test_linear_normalize_phase(self):
+        wnaxis = np.array([1000.0, 1500.0, 2000.0])
+        # Exactly linear phase; removing the fitted line should return zeros.
+        spectrum = np.array([1.0, 1.5, 2.0])
+
+        normalized = spectra.LinearNormalize(
+            wavenumber1=1000.0,
+            wavenumber2=2000.0,
+            datatype=spectra.DataTypes.Phase,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(normalized, np.zeros_like(spectrum), atol=1e-12)
+
+    def test_linear_normalize_amplitude(self):
+        wnaxis = np.array([1000.0, 1500.0, 2000.0])
+        # Exactly linear amplitude; division by the fitted line should return ones.
+        spectrum = np.array([2.0, 3.0, 4.0])
+
+        normalized = spectra.LinearNormalize(
+            wavenumber1=1000.0,
+            wavenumber2=2000.0,
+            datatype=spectra.DataTypes.Amplitude,
+        ).transform(spectrum, wnaxis)
+
+        np.testing.assert_allclose(normalized, np.ones_like(spectrum), atol=1e-12)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces several new spectrum transformation classes and extends the test coverage for these transformations in the `pySNOM` package. The main additions are the `Cut`, `Scale`, and `ConstantNormalize` transformations, as well as enhancements to the `RotatePhase` transformation. Comprehensive unit tests have been added to ensure correctness and reliability of these new and modified features.

**New spectrum transformation classes:**

* Added the `Cut` class to extract a spectral region between two wavenumbers from a spectrum (`pySNOM/spectra.py`).
* Added the `Scale` class to scale amplitude or phase data by a specified factor (`pySNOM/spectra.py`).
* Added the `ConstantNormalize` class for normalization by a constant value or by a value from the spectrum at a specific wavenumber, supporting both amplitude and phase data (`pySNOM/spectra.py`).

**Enhancements to existing transformations:**

* Modified the `RotatePhase` class to support an optional constant phase shift in addition to the wavenumber-scaled phase shift (`pySNOM/spectra.py`).

**Test coverage improvements:**

* Added comprehensive unit tests for the new `Cut`, `Scale`, and `ConstantNormalize` transformations, as well as for the enhanced `RotatePhase` and other normalization methods (`pySNOM/tests/test_spectra.py`).